### PR TITLE
Update libc and Rust repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-<div align="center">
-  <h1><code>cargo wasix</code></h1>
+# cargo-wasix
+
+A cargo subcommand that wraps regular cargo commands for compiling Rust code
+to `wasix`, a superset of Websassembly `wasi` with additional functionality.
+
+See [wasix.org](https://wasix.org) for more.
 
 ## Installation
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Custom rust repository.
-const RUST_REPO: &str = "https://github.com/wasmerio/rust.git";
+const RUST_REPO: &str = "https://github.com/wasix-org/rust.git";
 /// Branch to use in the custom Rust repo.
 const RUST_BRANCH: &str = "wasix";
 
@@ -200,7 +200,7 @@ fn build_libc(
     git_tag: Option<String>,
     update_repo: bool,
 ) -> Result<(), anyhow::Error> {
-    const LIBC_REPO: &str = "https://github.com/wasmerio/wasix-libc.git";
+    const LIBC_REPO: &str = "https://github.com/wasix-org/wasix-libc.git";
     /// Download url for LLVM + clang.
     const LLVM_LINUX_SOURCE: &str = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.2/clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz";
 


### PR DESCRIPTION
- docs: Update REAMDE to point to wasix.org
- fix: Update rust fork and wasix-libc repo urls
