### PR TITLE
Fix toolchain path sanity check for Windows

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -725,7 +725,12 @@ impl RustupToolchain {
         );
 
         // Small sanity check.
-        let rustc_path = dir.join("bin/rustc");
+        #[cfg(not(target_os = "windows"))]
+        let rustc_exe = "rustc";
+        #[cfg(target_os = "windows")]
+        let rustc_exe = "rustc.exe";
+
+        let rustc_path = dir.join("bin").join(rustc_exe);
         if !rustc_path.is_file() {
             bail!(
                 "Invalid toolchain directory: rustc executable not found at {}",


### PR DESCRIPTION
Fixes this issue where the sanity check of a correctly downloaded toolchain would fail on Windows because of wrong executable name

![immagine](https://github.com/wasix-org/cargo-wasix/assets/33133578/e79a8925-40ec-4dea-afc0-72b7cccb719b)
