### PR TITLE
Add basic check of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ exclude = ['tmp', 'target']
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 atty = "0.2"
+cargo_metadata = "0.15"
 dirs = "3.0.1"
 flate2 = "1"
 fs2 = "0.4"

--- a/incompatible_crates/README.md
+++ b/incompatible_crates/README.md
@@ -1,0 +1,9 @@
+The `data.json` file contains a list of crates that are known to be incompatible
+with wasix. The structure is defined in the `IncompatibleCrate` type in the
+code.
+
+## Backwards Compatibility
+
+Be careful when changing the structure of the data as previous version of
+cargo-wasix will use the same data. Any changes made should be backwards
+compatible.

--- a/incompatible_crates/data.json
+++ b/incompatible_crates/data.json
@@ -1,0 +1,12 @@
+[
+  {"name": "mio", "replacements": [
+    { "version": "0.8", "repo": "https://github.com/wasix-org/mio"}
+  ]},
+  {"name": "libc", "replacements": [
+    { "version": "0.2", "repo": "https://github.com/wasix-org/libc"}
+  ]},
+  {"name": "socket2", "replacements": [
+    { "version": "0.4", "repo": "https://github.com/wasix-org/socket2", "branch": "v0.4.9"},
+    { "version": "0.5", "repo": "https://github.com/wasix-org/socket2", "branch": "v0.5"}
+  ]}
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     cache: Option<Cache>,
     verbose: bool,
     choice: ColorChoice,
+    pub is_offline: bool,
 }
 
 impl Config {
@@ -20,6 +21,9 @@ impl Config {
             } else {
                 ColorChoice::Never
             },
+            // Offline env var disables toolchain downloads and update checks.
+            is_offline: std::env::var("CARGO_WASIX_OFFLINE")
+                .map_or(false, |v| v == "1" || v == "true"),
         }
     }
 

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -222,6 +222,10 @@ pub fn check(config: &Config, target: &str) -> Result<()> {
             }
         }
 
+        msg.push_str(
+            "\nYou might have to run `cargo update` to ensure the dependencies are used properly",
+        );
+
         if !no_replacements.is_empty() {
             msg.push_str("\nNo replacements found for the following dependencies:\n");
             for (name, replacements, version) in no_replacements {

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -71,6 +71,13 @@ fn download_known_incompatible_crates(
     config: &Config,
     path: &Path,
 ) -> Result<Vec<IncompatibleCrate>> {
+    if config.is_offline {
+        static INCLUDED_CRATES: &str = include_str!("../incompatible_crates/data.json");
+        // NOTE: we don't cache this file as this may be really outdated.
+        return serde_json::from_str(INCLUDED_CRATES)
+            .with_context(|| format!("failed to deserialize incompatible crates"));
+    }
+
     let url = KNOWN_INCOMPATIBLE_CRATES_URL;
 
     config.status("Downloading", "known incompatible crates list");

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,0 +1,180 @@
+//! Module with check related to the dependencies.
+
+use crate::config::Config;
+use crate::utils::{self, CommandExt};
+use anyhow::{bail, Context, Result};
+use std::collections::hash_map::{self, HashMap};
+use std::fs;
+use std::io;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
+use std::process::Command;
+
+const KNOWN_INCOMPATIBLE_CRATES_URL: &str =
+    "https://github.com/wasix-org/cargo-wasix/tree/main/incompatible_crates/data.json";
+
+/// Known incompatible crate.
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+struct IncompatibleCrate {
+    /// Name of the crate.
+    name: String,
+    /// Version(s) that are known to be compatible. If this is `None` we
+    /// assume that all versions are incompatible.
+    /// For example `>= 0.9` can be used to indicate the version 0.9 gained
+    /// support for wasix.
+    compatible_versions: Option<cargo_metadata::semver::VersionReq>,
+    /// Replacement dependency that supports wasix.
+    replacements: Vec<Replacement>,
+}
+
+/// Replacement crate for an `IncompatibleCrate`.
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+struct Replacement {
+    /// Version that needs to be used, in case the latest version isn't
+    /// supported.
+    version: String, // cargo_metadata::semver::Version,
+    /// Git repository to use.
+    repo: String,
+    /// Git branch to use.
+    branch: Option<String>,
+}
+
+fn known_incompatible_crates(config: &Config) -> Vec<IncompatibleCrate> {
+    match read_known_incompatible_crates(config) {
+        Ok(crates) => crates,
+        Err(err) => {
+            config.print_error(&err.context("not checking known incompatible crates"));
+            Vec::new()
+        }
+    }
+}
+
+fn read_known_incompatible_crates(config: &Config) -> Result<Vec<IncompatibleCrate>> {
+    let mut path = Config::cache_dir()?;
+    path.push("incompatible_crates.json");
+
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
+            // Don't have to file cached yet, let's do that now.
+            return download_known_incompatible_crates(config, &path);
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read '{}'", path.display()))
+        }
+    };
+    serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("failed to deserialize '{}'", path.display()))
+}
+
+fn download_known_incompatible_crates(
+    config: &Config,
+    path: &Path,
+) -> Result<Vec<IncompatibleCrate>> {
+    let url = KNOWN_INCOMPATIBLE_CRATES_URL;
+
+    config.status("Downloading", "known incompatible crates list");
+    config.verbose(|| config.status("Get", url));
+
+    let response = utils::get(url)?;
+    let incompatible_crates = response
+        .json()
+        .with_context(|| format!("failed to deserialize incompatible crates"))?;
+
+    let dir = path.parent().unwrap_or(path);
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create cache directory '{}'", dir.display()))?;
+    let file =
+        fs::File::create(path).with_context(|| format!("failed to read '{}'", path.display()))?;
+    let mut file = BufWriter::new(file);
+    serde_json::to_writer(&mut file, &incompatible_crates).with_context(|| {
+        format!(
+            "failed to write incompatible crates to '{}'",
+            path.display()
+        )
+    })?;
+    file.flush().with_context(|| {
+        format!(
+            "failed to write incompatible crates to '{}'",
+            path.display()
+        )
+    })?;
+
+    Ok(incompatible_crates)
+}
+
+/// Check the dependencies with well-known incompatible crates.
+pub fn check(config: &Config, target: &str) -> Result<()> {
+    let metadata = Command::new("cargo")
+        .arg("metadata")
+        .arg("--format-version=1")
+        // Only resolve dependencies for our target.
+        .arg("--filter-platform")
+        .arg(target)
+        .capture_stdout()?;
+    let metadata = serde_json::from_str::<cargo_metadata::Metadata>(&metadata)
+        .context("failed to deserialize `cargo metadata`")?;
+
+    let resolve = metadata
+        .resolve
+        .as_ref()
+        .context("failed to resolve root package")?;
+    let root_pkg_id = resolve
+        .root
+        .as_ref()
+        .context("failed to resolve root package")?;
+
+    // First we crate a map of all dependencies, and the dependencies of the
+    // dependencies, etc.
+    let mut dependencies = HashMap::new();
+    let mut to_check = vec![root_pkg_id];
+    while let Some(pkg_id) = to_check.pop() {
+        let Some(node) = resolve.nodes.iter().find(|n| n.id == *pkg_id) else { continue; };
+        for dependency in &node.deps {
+            if is_build_dep(&dependency.dep_kinds) {
+                continue;
+            }
+
+            match dependencies.entry(&dependency.name) {
+                hash_map::Entry::Occupied(_) => { /* Already handled. */ }
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(&dependency.pkg);
+                    to_check.push(&dependency.pkg);
+                }
+            }
+        }
+    }
+
+    let mut found_incompatible_crates = Vec::new();
+    let known_incompatible_crates = known_incompatible_crates(config);
+    for incompatible_crate in &known_incompatible_crates {
+        if let Some(pkg_id) = dependencies.get(&incompatible_crate.name) {
+            let Some(pkg) = metadata.packages.iter().find(|pkg| pkg.id == **pkg_id) else { continue; };
+
+            // Filter out versions that are known to compatible.
+            if let Some(versions) = &incompatible_crate.compatible_versions {
+                if versions.matches(&pkg.version) {
+                    continue;
+                }
+            }
+
+            found_incompatible_crates.push(&incompatible_crate.name);
+        }
+    }
+
+    if found_incompatible_crates.is_empty() {
+        Ok(())
+    } else {
+        // TODO: better error message:
+        // * better formatting of crates.
+        // * explain to the user how to fix it.
+        bail!("found incompatible crates in dependencies (of dependencies): {found_incompatible_crates:?}",);
+    }
+}
+
+fn is_build_dep(dep_kinds: &[cargo_metadata::DepKindInfo]) -> bool {
+    use cargo_metadata::DependencyKind::*;
+    !dep_kinds
+        .iter()
+        .any(|d| matches!(d.kind, Normal | Development))
+}

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -164,6 +164,13 @@ pub fn check(config: &Config, target: &str) -> Result<()> {
         if let Some(pkg_id) = dependencies.get(&incompatible_crate.name) {
             let Some(pkg) = metadata.packages.iter().find(|pkg| pkg.id == **pkg_id) else { continue; };
 
+            if let Some(source) = pkg.source.as_ref() {
+                if source.repr.starts_with("git+https://github.com/wasix-org") {
+                    // Already using a replacement crate.
+                    continue;
+                }
+            }
+
             // Filter out versions that are known to compatible.
             if let Some(versions) = &incompatible_crate.compatible_versions {
                 if versions.matches(&pkg.version) {

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -9,6 +9,11 @@ use std::io;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
+
+/// Timeout for downling the incompatible crates data from
+/// [`KNOWN_INCOMPATIBLE_CRATES_URL`].
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 
 const KNOWN_INCOMPATIBLE_CRATES_URL: &str =
     "https://github.com/wasix-org/cargo-wasix/tree/main/incompatible_crates/data.json";
@@ -83,7 +88,7 @@ fn download_known_incompatible_crates(
     config.status("Downloading", "known incompatible crates list");
     config.verbose(|| config.status("Get", url));
 
-    let response = utils::get(url)?;
+    let response = utils::get(url, DOWNLOAD_TIMEOUT)?;
     let incompatible_crates = response
         .json()
         .with_context(|| format!("failed to deserialize incompatible crates"))?;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -8,6 +8,8 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
+const UPDATE_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn main(args: &[OsString], config: &Config) -> Result<()> {
     match args.get(0).and_then(|s| s.to_str()) {
         Some("clean") => clean(config),
@@ -50,7 +52,7 @@ fn update_available() -> Result<Option<Version>> {
     }
 
     let url = "https://crates.io/api/v1/crates/cargo-wasix";
-    let response = crate::utils::get(url)?;
+    let response = crate::utils::get(url, UPDATE_TIMEOUT)?;
     let json = response
         .json::<Info>()
         .context(format!("failed to decode json from `{}`", url))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 use tool_path::ToolPath;
 
 mod cache;
@@ -17,6 +18,9 @@ mod internal;
 mod tool_path;
 mod toolchain;
 mod utils;
+
+/// Timeout used by [`download`].
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn main() {
     // See comments in `rmain` around `*_RUNNER` for why this exists here.
@@ -667,7 +671,7 @@ fn download(
     config.status("Downloading", name);
     config.verbose(|| config.status("Get", url));
 
-    let response = utils::get(url)?;
+    let response = utils::get(url, DOWNLOAD_TIMEOUT)?;
     (|| -> Result<()> {
         fs::create_dir_all(parent)
             .context(format!("failed to create directory `{}`", parent.display()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,21 @@ use crate::cache::Cache;
 use crate::config::Config;
 use crate::utils::CommandExt;
 use anyhow::{bail, Context, Result};
-use std::collections::hash_map::{self, HashMap};
 use std::env;
 use std::fs;
 use std::io;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tool_path::ToolPath;
 
 mod cache;
 mod config;
+mod dependencies;
 mod internal;
 mod tool_path;
 mod toolchain;
 mod utils;
-
-const KNOWN_INCOMPATIBLE_CRATES_URL: &str =
-    "https://github.com/wasix-org/cargo-wasix/tree/main/incompatible_crates/data.json";
 
 pub fn main() {
     // See comments in `rmain` around `*_RUNNER` for why this exists here.
@@ -249,7 +246,7 @@ fn rmain(config: &mut Config) -> Result<()> {
 
     // Check the dependencies, if needed, before running cargo.
     if check_deps {
-        check_dependencies(config, target)?;
+        dependencies::check(config, target)?;
     }
 
     // Run the cargo commands
@@ -556,172 +553,6 @@ fn execute_cargo(cargo: &mut Command, config: &Config) -> Result<CargoBuild> {
     }
 
     Ok(build)
-}
-
-/// Known incompatible crate.
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
-struct IncompatibleCrate {
-    /// Name of the crate.
-    name: String,
-    /// Version(s) that are known to be compatible. If this is `None` we
-    /// assume that all versions are incompatible.
-    /// For example `>= 0.9` can be used to indicate the version 0.9 gained
-    /// support for wasix.
-    compatible_versions: Option<cargo_metadata::semver::VersionReq>,
-    /// Replacement dependency that supports wasix.
-    replacements: Vec<Replacement>,
-}
-
-/// Replacement crate for an `IncompatibleCrate`.
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
-struct Replacement {
-    /// Version that needs to be used, in case the latest version isn't
-    /// supported.
-    version: String, // cargo_metadata::semver::Version,
-    /// Git repository to use.
-    repo: String,
-    /// Git branch to use.
-    branch: Option<String>,
-}
-
-fn known_incompatible_crates(config: &Config) -> Vec<IncompatibleCrate> {
-    match read_known_incompatible_crates(config) {
-        Ok(crates) => crates,
-        Err(err) => {
-            config.print_error(&err.context("not checking known incompatible crates"));
-            Vec::new()
-        }
-    }
-}
-
-fn read_known_incompatible_crates(config: &Config) -> Result<Vec<IncompatibleCrate>> {
-    let mut path = Config::cache_dir()?;
-    path.push("incompatible_crates.json");
-
-    let file = match fs::File::open(&path) {
-        Ok(file) => file,
-        Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
-            // Don't have to file cached yet, let's do that now.
-            return download_known_incompatible_crates(config, &path);
-        }
-        Err(err) => {
-            return Err(err).with_context(|| format!("failed to read '{}'", path.display()))
-        }
-    };
-    serde_json::from_reader(BufReader::new(file))
-        .with_context(|| format!("failed to deserialize '{}'", path.display()))
-}
-
-fn download_known_incompatible_crates(
-    config: &Config,
-    path: &Path,
-) -> Result<Vec<IncompatibleCrate>> {
-    let url = KNOWN_INCOMPATIBLE_CRATES_URL;
-
-    config.status("Downloading", "known incompatible crates list");
-    config.verbose(|| config.status("Get", url));
-
-    let response = utils::get(url)?;
-    let incompatible_crates = response
-        .json()
-        .with_context(|| format!("failed to deserialize incompatible crates"))?;
-
-    let dir = path.parent().unwrap_or(path);
-    fs::create_dir_all(dir)
-        .with_context(|| format!("failed to create cache directory '{}'", dir.display()))?;
-    let file =
-        fs::File::create(path).with_context(|| format!("failed to read '{}'", path.display()))?;
-    let mut file = BufWriter::new(file);
-    serde_json::to_writer(&mut file, &incompatible_crates).with_context(|| {
-        format!(
-            "failed to write incompatible crates to '{}'",
-            path.display()
-        )
-    })?;
-    file.flush().with_context(|| {
-        format!(
-            "failed to write incompatible crates to '{}'",
-            path.display()
-        )
-    })?;
-
-    Ok(incompatible_crates)
-}
-
-/// Check the dependencies with well-known incompatible crates.
-fn check_dependencies(config: &Config, target: &str) -> Result<()> {
-    let metadata = Command::new("cargo")
-        .arg("metadata")
-        .arg("--format-version=1")
-        // Only resolve dependencies for our target.
-        .arg("--filter-platform")
-        .arg(target)
-        .capture_stdout()?;
-    let metadata = serde_json::from_str::<cargo_metadata::Metadata>(&metadata)
-        .context("failed to deserialize `cargo metadata`")?;
-
-    let resolve = metadata
-        .resolve
-        .as_ref()
-        .context("failed to resolve root package")?;
-    let root_pkg_id = resolve
-        .root
-        .as_ref()
-        .context("failed to resolve root package")?;
-
-    // First we crate a map of all dependencies, and the dependencies of the
-    // dependencies, etc.
-    let mut dependencies = HashMap::new();
-    let mut to_check = vec![root_pkg_id];
-    while let Some(pkg_id) = to_check.pop() {
-        let Some(node) = resolve.nodes.iter().find(|n| n.id == *pkg_id) else { continue; };
-        for dependency in &node.deps {
-            if is_build_dep(&dependency.dep_kinds) {
-                continue;
-            }
-
-            match dependencies.entry(&dependency.name) {
-                hash_map::Entry::Occupied(_) => { /* Already handled. */ }
-                hash_map::Entry::Vacant(entry) => {
-                    entry.insert(&dependency.pkg);
-                    to_check.push(&dependency.pkg);
-                }
-            }
-        }
-    }
-
-    let mut found_incompatible_crates = Vec::new();
-    let known_incompatible_crates = known_incompatible_crates(config);
-    for incompatible_crate in &known_incompatible_crates {
-        if let Some(pkg_id) = dependencies.get(&incompatible_crate.name) {
-            let Some(pkg) = metadata.packages.iter().find(|pkg| pkg.id == **pkg_id) else { continue; };
-
-            // Filter out versions that are known to compatible.
-            if let Some(versions) = &incompatible_crate.compatible_versions {
-                if versions.matches(&pkg.version) {
-                    continue;
-                }
-            }
-
-            found_incompatible_crates.push(&incompatible_crate.name);
-        }
-    }
-
-    if found_incompatible_crates.is_empty() {
-        Ok(())
-    } else {
-        // TODO: better error message:
-        // * better formatting of crates.
-        // * explain to the user how to fix it.
-        bail!("found incompatible crates in dependencies (of dependencies): {found_incompatible_crates:?}",);
-    }
-}
-
-fn is_build_dep(dep_kinds: &[cargo_metadata::DepKindInfo]) -> bool {
-    use cargo_metadata::DependencyKind::*;
-    !dep_kinds
-        .iter()
-        .any(|d| matches!(d.kind, Normal | Development))
 }
 
 /// Attempts to execute `cmd` which is executing `requested`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,16 +219,12 @@ fn rmain(config: &mut Config) -> Result<()> {
         Subcommand::Tree | Subcommand::Fix => {}
     }
 
-    // Offline env var disables toolchain downloads and update checks.
-    let is_offline =
-        std::env::var("CARGO_WASIX_OFFLINE").map_or(false, |v| v == "1" || v == "true");
-
-    let update_check_opt = if is_offline {
+    let update_check_opt = if config.is_offline {
         Some(internal::UpdateCheck::new(config))
     } else {
         None
     };
-    let toolchain = toolchain::ensure_toolchain(config, is64bit, is_offline)?;
+    let toolchain = toolchain::ensure_toolchain(config, is64bit)?;
 
     std::env::set_var("RUSTUP_TOOLCHAIN", &toolchain.name);
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -780,16 +780,12 @@ impl RustupToolchain {
 /// Also checks that the toolchain is correctly installed.
 ///
 /// Returns the path to the toolchain.
-pub fn ensure_toolchain(
-    _config: &Config,
-    is64bit: bool,
-    is_offline: bool,
-) -> Result<RustupToolchain, anyhow::Error> {
+pub fn ensure_toolchain(config: &Config, is64bit: bool) -> Result<RustupToolchain, anyhow::Error> {
     let _lock = Config::acquire_lock()?;
 
     let toolchain = if let Some(chain) = RustupToolchain::find_by_name(RUSTUP_TOOLCHAIN_NAME)? {
         chain
-    } else if !is_offline {
+    } else if !config.is_offline {
         install_prebuilt_toolchain(&Config::toolchain_dir()?)?
     } else {
         bail!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::process::{Command, ExitStatus, Output, Stdio};
+use std::time::Duration;
 use std::{env, fmt};
 
 /// Make sure a binary exists and runs with the given arguments.
@@ -185,8 +186,11 @@ fn get_http_proxy() -> Option<String> {
         .and_then(|v| v.ok())
 }
 
-pub fn get(url: &str) -> Result<Response> {
-    let mut client = Client::builder();
+pub fn get(url: &str, timeout: Duration) -> Result<Response> {
+    let mut client = Client::builder()
+        // This is only for the connect phase.
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(timeout);
     if let Some(proxy_url) = get_http_proxy() {
         if let Ok(proxy) = Proxy::all(&proxy_url) {
             client = client.proxy(proxy);


### PR DESCRIPTION
Very much a work in progress, but a start to fix #21.

Currently this prints something along the following lines when it finds an incompatible crates:
```
error: found incompatible crates in dependencies: ["mio"]
```