### PR TITLE
add support for downloading specific version of toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,8 @@ fn rmain(config: &mut Config) -> Result<()> {
             let version = args
                 .first()
                 .cloned()
-                .map(|v| v.into_string().unwrap())
-                .unwrap_or("latest".to_owned());
+                .map(|v| v.into_string().unwrap().into())
+                .unwrap_or(toolchain::ToolchainSpec::Latest);
             let _lock = Config::acquire_lock()?;
             let chain = toolchain::install_prebuilt_toolchain(&Config::toolchain_dir()?, version)?;
             config.info(&format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,9 @@ fn rmain(config: &mut Config) -> Result<()> {
     if !no_message_format {
         cargo.arg("--message-format").arg("json-render-diagnostics");
     }
-    for arg in args {
+
+    let args = args.collect::<Vec<_>>();
+    for arg in args.clone() {
         if let Some(arg) = arg.to_str() {
             if arg.starts_with("--verbose") || arg.starts_with("-v") {
                 config.set_verbose(true);
@@ -178,8 +180,13 @@ fn rmain(config: &mut Config) -> Result<()> {
     let mut check_deps = false;
     match subcommand {
         Subcommand::DownloadToolchain => {
+            let version = args
+                .first()
+                .cloned()
+                .map(|v| v.into_string().unwrap())
+                .unwrap_or("latest".to_owned());
             let _lock = Config::acquire_lock()?;
-            let chain = toolchain::install_prebuilt_toolchain(&Config::toolchain_dir()?)?;
+            let chain = toolchain::install_prebuilt_toolchain(&Config::toolchain_dir()?, version)?;
             config.info(&format!(
                 "Toolchain {} downloaded and installed to path {}.\nThe wasix toolchain is now ready to use.",
                 chain.name,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -6,7 +6,9 @@
 //! * Build the whole toolchain
 
 use std::{
-    fmt::Display, path::{Path, PathBuf}, process::Command
+    fmt::Display,
+    path::{Path, PathBuf},
+    process::Command,
 };
 
 use anyhow::{bail, Context};
@@ -900,8 +902,8 @@ mod tests {
         if tmp_dir.is_dir() {
             std::fs::remove_dir_all(&tmp_dir).unwrap_or_default();
         }
-        let root =
-            download_toolchain("x86_64-unknown-linux-gnu", &tmp_dir, ToolchainSpec::Latest).unwrap();
+        let root = download_toolchain("x86_64-unknown-linux-gnu", &tmp_dir, ToolchainSpec::Latest)
+            .unwrap();
         let dir = root.join("rust");
 
         #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
This PR adds support for downloading a specific version of the toolchain. For example:
```bash
cargo wasix download-toolchain v2024-06-26.1
```
if no version is specified, it will fetch the latest release which is compatible with the old behavior.