### PR TITLE
fix: fix cargo-wasix build by running host cargo with wasix rustc/rusdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@ fn rmain(config: &mut Config) -> Result<()> {
     };
 
     let mut cargo = Command::new("cargo");
-    cargo.arg("+wasix");
     cargo.arg(match subcommand {
         Subcommand::Build => "build",
         Subcommand::DownloadToolchain => "download-toolchain",
@@ -208,8 +207,10 @@ fn rmain(config: &mut Config) -> Result<()> {
         None
     };
     let toolchain = toolchain::ensure_toolchain(config)?;
-
-    std::env::set_var("RUSTUP_TOOLCHAIN", &toolchain.name);
+    let rustc_path = toolchain.bin("rustc");
+    let rustdoc_path = toolchain.bin("rustdoc");
+    std::env::set_var("RUSTC", &rustc_path);
+    std::env::set_var("RUSTDOC", &rustdoc_path);
 
     // Set some flags for rustc (only if RUSTFLAGS is not already set)
     if std::env::var("RUSTFLAGS").is_err() {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -306,6 +306,16 @@ impl RustupToolchain {
             path: dir.into(),
         })
     }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn bin(&self, name: &str) -> PathBuf {
+        self.path.join("bin").join(name)
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn bin(&self, name: &str) -> PathBuf {
+        self.path.join("bin").join(name).with_extension("exe")
+    }
 }
 
 /// Makes sure that the wasix toolchain is available by


### PR DESCRIPTION
`cargo wasix build` fails after installation with an error
```
$ cargo wasix build                                           
error: 'cargo' is not installed for the custom toolchain 'wasix'.
note: this is a custom toolchain, which cannot use `rustup component add`
help: if you built this toolchain from source, and used `rustup toolchain link`, then you may be able to build the component with `x.py`
warn: failed to check dependencies: failed to execute "cargo" "metadata" "--format-version=1" "--filter-platform" "wasm32-wasmer-wasi"
    status: exit status: 1
```

It's caused by `cargo wasix` using `cargo +wasix`, which made `rustup` look for a `cargo` binary inside the `wasix` toolchain that only ships `rustc/rustdoc`, so build failed with `cargo is not installed for wasix.` 

Simple way to validate is following Dockerfile
```Dockerfile
FROM rust:1.91-slim-bookworm
WORKDIR /src
COPY . .
RUN cargo build
RUN cp target/debug/cargo-wasix /usr/local/bin/cargo-wasix
RUN cargo wasix download-toolchain
RUN cargo wasix --version

WORKDIR /app
RUN cargo init
RUN cargo wasix build
```


With changes in this PR the docker build completes fine. If you want I can integrate this to Github Actions?

Closes https://github.com/wasix-org/cargo-wasix/issues/12

