### PR TITLE
feat: enable 3 WA Features by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,10 @@ fn rmain(config: &mut Config) -> Result<()> {
 
     // Set some flags for rustc (only if RUSTFLAGS is not already set)
     if std::env::var("RUSTFLAGS").is_err() {
-        env::set_var("RUSTFLAGS", "-C target-feature=+atomics");
+        env::set_var(
+            "RUSTFLAGS",
+            "-C target-feature=+atomics,+simd128,+relaxed-simd,+extended-const",
+        );
     }
 
     // Check the dependencies, if needed, before running cargo.


### PR DESCRIPTION
With the release of Wasmer 7.1, we're able to leverage new WebAssembly features and it would be good to rely on them by default.