### PR TITLE
Add reusable GitHub Action and release v0.1.27.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,14 @@ jobs:
         shell: bash
         run: |
           cargo build --release
+
+  action-smoke:
+    name: setup action smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./
+        with:
+          version: "0.1.26"
+      - run: cargo wasix --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-wasix"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2024"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,55 @@ irm https://github.com/wasix-org/cargo-wasix/releases/latest/download/cargo-wasi
 $ cargo wasix --version
 ```
 
+### GitHub Actions
+
+Install `cargo-wasix` and the WASIX toolchain in CI using the composite action
+published from this repository. Rust and rustup must already be on `PATH` (e.g.
+via [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)).
+
+Minimal example:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: dtolnay/rust-toolchain@stable
+- uses: wasix-org/cargo-wasix@v0.1.27
+- run: cargo wasix build
+```
+
+The action ref determines the default `cargo-wasix` version — `uses:
+wasix-org/cargo-wasix@v0.1.27` installs `0.1.27` without an explicit
+`with.version`. Prefer tagged refs for reproducible CI.
+
+#### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `version` | no | `""` | crates.io version of `cargo-wasix`. Empty uses the `version` from `Cargo.toml` at the action ref. |
+| `toolchain-version` | no | `""` | WASIX Rust toolchain tag (e.g. `v2026-06-09.1+rust-1.90`). Empty downloads the latest toolchain. |
+| `locked` | no | `"true"` | Pass `--locked` to `cargo install`. |
+
+#### Full example
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  wasix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: wasix-org/cargo-wasix@v0.1.27
+        with:
+          version: "0.1.27"
+          toolchain-version: v2026-06-09.1+rust-1.90
+          locked: "true"
+      - run: cargo wasix build
+      - run: cargo wasix test
+```
+
 ## Usage
 
 The `cargo wasix` subcommand is a thin wrapper around `cargo` subcommands,

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,59 @@
+name: Setup cargo-wasix
+description: Install cargo-wasix and download the WASIX toolchain (requires Rust/cargo/rustup on PATH)
+branding:
+  color: purple
+  icon: package
+inputs:
+  version:
+    description: cargo-wasix version (empty = version from Cargo.toml at action ref)
+    required: false
+    default: ""
+  toolchain-version:
+    description: WASIX toolchain tag (empty = latest)
+    required: false
+    default: ""
+  locked:
+    description: Use --locked when installing
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Check prerequisites
+      shell: bash
+      run: |
+        command -v cargo >/dev/null || {
+          echo "::error::cargo not found — add dtolnay/rust-toolchain@stable before this action"
+          exit 1
+        }
+        command -v rustup >/dev/null || {
+          echo "::error::rustup not found — add dtolnay/rust-toolchain@stable before this action"
+          exit 1
+        }
+    - name: Install cargo-wasix
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.version }}" ]]; then
+          VERSION="${{ inputs.version }}"
+        else
+          VERSION=$(grep -m1 '^version' "${{ github.action_path }}/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+        fi
+        echo "Installing cargo-wasix $VERSION"
+        args=(cargo-wasix --version "$VERSION")
+        if [[ "${{ inputs.locked }}" == "true" ]]; then
+          args+=(--locked)
+        fi
+        cargo install "${args[@]}"
+    - name: Verify installation
+      shell: bash
+      run: cargo wasix --version
+    - name: Download WASIX toolchain
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        if [[ -n "${{ inputs.toolchain-version }}" ]]; then
+          cargo wasix download-toolchain "${{ inputs.toolchain-version }}"
+        else
+          cargo wasix download-toolchain
+        fi


### PR DESCRIPTION
Publish a composite action that installs cargo-wasix and downloads the WASIX toolchain, so consumers can use wasix-org/cargo-wasix@v0.1.27 in CI.