### PR TITLE
Add -W, wasmer pass-through and test/bench runtime defaults

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -61,7 +61,10 @@ mod tests {
         let (cargo, wasmer) =
             split_cargo_and_wasmer_args(args.iter().map(|s| OsString::from(*s))).unwrap();
         (
-            cargo.into_iter().map(|s| s.into_string().unwrap()).collect(),
+            cargo
+                .into_iter()
+                .map(|s| s.into_string().unwrap())
+                .collect(),
             wasmer,
         )
     }
@@ -70,7 +73,10 @@ mod tests {
     fn splits_comma_separated_runtime_args() {
         assert_eq!(
             split(&["-W,--mapdir,/tmp:/tmp"]),
-            (vec![], vec!["--mapdir".to_string(), "/tmp:/tmp".to_string()])
+            (
+                vec![],
+                vec!["--mapdir".to_string(), "/tmp:/tmp".to_string()]
+            )
         );
     }
 
@@ -94,7 +100,11 @@ mod tests {
         assert_eq!(
             split(&["-W,--foo", "--", "-W,--bar", "guest"]),
             (
-                vec!["--".to_string(), "-W,--bar".to_string(), "guest".to_string()],
+                vec![
+                    "--".to_string(),
+                    "-W,--bar".to_string(),
+                    "guest".to_string()
+                ],
                 vec!["--foo".to_string()]
             )
         );

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,126 @@
+use anyhow::{Result, bail};
+use std::ffi::OsString;
+
+/// Split user arguments into cargo-forwarded args and wasmer/runtime args.
+///
+/// Recognizes clang-style `-W,<args>` tokens (comma-separated runtime args).
+/// Parsing stops at the first bare `--`; everything from `--` onward goes to
+/// cargo unchanged.
+pub fn split_cargo_and_wasmer_args(
+    args: impl IntoIterator<Item = OsString>,
+) -> Result<(Vec<OsString>, Vec<String>)> {
+    let mut cargo_args = Vec::new();
+    let mut wasmer_args = Vec::new();
+    let mut iter = args.into_iter().peekable();
+
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            cargo_args.push(arg);
+            cargo_args.extend(iter);
+            break;
+        }
+
+        let Some(text) = arg.to_str() else {
+            cargo_args.push(arg);
+            continue;
+        };
+
+        if let Some(rest) = text.strip_prefix("-W,") {
+            if rest.is_empty() {
+                bail!("`-W,` must be followed by at least one runtime argument");
+            }
+            let mut saw_segment = false;
+            for segment in rest.split(',') {
+                if segment.is_empty() {
+                    bail!("`-W,` contains an empty comma-separated segment");
+                }
+                wasmer_args.push(segment.to_string());
+                saw_segment = true;
+            }
+            if !saw_segment {
+                bail!("`-W,` must be followed by at least one runtime argument");
+            }
+            continue;
+        }
+
+        if text == "-W" || text.starts_with("-W") && !text.starts_with("-W,") {
+            bail!("runtime arguments must use `-W,<args>` syntax (like clang's `-Wl,`)");
+        }
+
+        cargo_args.push(arg);
+    }
+
+    Ok((cargo_args, wasmer_args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(args: &[&str]) -> (Vec<String>, Vec<String>) {
+        let (cargo, wasmer) =
+            split_cargo_and_wasmer_args(args.iter().map(|s| OsString::from(*s))).unwrap();
+        (
+            cargo.into_iter().map(|s| s.into_string().unwrap()).collect(),
+            wasmer,
+        )
+    }
+
+    #[test]
+    fn splits_comma_separated_runtime_args() {
+        assert_eq!(
+            split(&["-W,--mapdir,/tmp:/tmp"]),
+            (vec![], vec!["--mapdir".to_string(), "/tmp:/tmp".to_string()])
+        );
+    }
+
+    #[test]
+    fn splits_multiple_runtime_tokens_in_order() {
+        assert_eq!(
+            split(&["-W,--foo", "--release", "-W,--bar,--baz"]),
+            (
+                vec!["--release".to_string()],
+                vec![
+                    "--foo".to_string(),
+                    "--bar".to_string(),
+                    "--baz".to_string(),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn stops_parsing_at_double_dash() {
+        assert_eq!(
+            split(&["-W,--foo", "--", "-W,--bar", "guest"]),
+            (
+                vec!["--".to_string(), "-W,--bar".to_string(), "guest".to_string()],
+                vec!["--foo".to_string()]
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_bare_w_flag() {
+        let err = split_cargo_and_wasmer_args([OsString::from("-W")]).unwrap_err();
+        assert!(err.to_string().contains("`-W,<args>`"));
+    }
+
+    #[test]
+    fn rejects_w_flag_without_comma() {
+        let err = split_cargo_and_wasmer_args([OsString::from("-W--foo")]).unwrap_err();
+        assert!(err.to_string().contains("`-W,<args>`"));
+    }
+
+    #[test]
+    fn rejects_empty_w_comma() {
+        let err = split_cargo_and_wasmer_args([OsString::from("-W,")]).unwrap_err();
+        assert!(err.to_string().contains("at least one runtime argument"));
+    }
+
+    #[test]
+    fn rejects_empty_segment() {
+        let err = split_cargo_and_wasmer_args([OsString::from("-W,--foo,,")]).unwrap_err();
+        assert!(err.to_string().contains("empty comma-separated segment"));
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use std::ffi::OsString;
 
 /// Split user arguments into cargo-forwarded args and wasmer/runtime args.
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 /// cargo unchanged.
 pub fn split_cargo_and_wasmer_args(
     args: impl IntoIterator<Item = OsString>,
-) -> Result<(Vec<OsString>, Vec<String>)> {
+) -> Result<(Vec<OsString>, Vec<OsString>)> {
     let mut cargo_args = Vec::new();
     let mut wasmer_args = Vec::new();
     let mut iter = args.into_iter().peekable();
@@ -20,31 +20,27 @@ pub fn split_cargo_and_wasmer_args(
             break;
         }
 
-        let Some(text) = arg.to_str() else {
-            cargo_args.push(arg);
-            continue;
-        };
+        let text = arg.to_str().context("argument must be valid UTF-8")?;
+
+        if text == "-W" || text.starts_with("-W") && !text.starts_with("-W,") {
+            bail!("runtime arguments must use `-W,<args>` syntax (like clang's `-Wl,`)");
+        }
 
         if let Some(rest) = text.strip_prefix("-W,") {
             if rest.is_empty() {
                 bail!("`-W,` must be followed by at least one runtime argument");
             }
-            let mut saw_segment = false;
-            for segment in rest.split(',') {
+            let segments: Vec<&str> = rest.split(',').collect();
+            if segments.is_empty() {
+                bail!("`-W,` must be followed by at least one runtime argument");
+            }
+            for segment in segments {
                 if segment.is_empty() {
                     bail!("`-W,` contains an empty comma-separated segment");
                 }
-                wasmer_args.push(segment.to_string());
-                saw_segment = true;
-            }
-            if !saw_segment {
-                bail!("`-W,` must be followed by at least one runtime argument");
+                wasmer_args.push(OsString::from(segment));
             }
             continue;
-        }
-
-        if text == "-W" || text.starts_with("-W") && !text.starts_with("-W,") {
-            bail!("runtime arguments must use `-W,<args>` syntax (like clang's `-Wl,`)");
         }
 
         cargo_args.push(arg);
@@ -65,7 +61,10 @@ mod tests {
                 .into_iter()
                 .map(|s| s.into_string().unwrap())
                 .collect(),
-            wasmer,
+            wasmer
+                .into_iter()
+                .map(|s| s.into_string().unwrap())
+                .collect(),
         )
     }
 
@@ -132,5 +131,14 @@ mod tests {
     fn rejects_empty_segment() {
         let err = split_cargo_and_wasmer_args([OsString::from("-W,--foo,,")]).unwrap_err();
         assert!(err.to_string().contains("empty comma-separated segment"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn rejects_non_utf8_argument() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let err = split_cargo_and_wasmer_args([OsString::from_vec(vec![0xff])]).unwrap_err();
+        assert!(err.to_string().contains("valid UTF-8"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,12 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 use tool_path::ToolPath;
 
+mod args;
 mod cache;
 mod config;
 mod dependencies;
 mod internal;
+mod runtime;
 mod tool_path;
 mod toolchain;
 mod utils;
@@ -89,7 +91,7 @@ fn rmain(config: &mut Config) -> Result<()> {
 
     let mut cargo = Command::new("cargo");
     cargo.arg("+wasix");
-    cargo.arg(match subcommand {
+    cargo.arg(match &subcommand {
         Subcommand::Build => "build",
         Subcommand::DownloadToolchain => "download-toolchain",
         Subcommand::Check => "check",
@@ -100,7 +102,7 @@ fn rmain(config: &mut Config) -> Result<()> {
         Subcommand::Run => "run",
     });
 
-    let manifest_config = if matches!(subcommand, Subcommand::DownloadToolchain) {
+    let manifest_config = if matches!(&subcommand, Subcommand::DownloadToolchain) {
         Default::default()
     } else {
         read_manifest_config()?
@@ -118,7 +120,8 @@ fn rmain(config: &mut Config) -> Result<()> {
     }
 
     let args = args.collect::<Vec<_>>();
-    for arg in args.clone() {
+    let (cargo_args, wasmer_args) = args::split_cargo_and_wasmer_args(args)?;
+    for arg in cargo_args.iter() {
         if let Some(arg) = arg.to_str()
             && (arg.starts_with("--verbose") || arg.starts_with("-v"))
         {
@@ -127,6 +130,17 @@ fn rmain(config: &mut Config) -> Result<()> {
 
         cargo.arg(arg);
     }
+
+    let runtime_args = match &subcommand {
+        Subcommand::Test | Subcommand::Bench => {
+            let manifest_dir = runtime::resolve_manifest_dir(&cargo_args)?;
+            let mut runtime_args = runtime::default_runtime_args(&manifest_dir)?;
+            runtime_args.extend(wasmer_args);
+            runtime_args
+        }
+        Subcommand::Run => wasmer_args,
+        _ => Vec::new(),
+    };
 
     let runner_env_var = format!(
         "CARGO_TARGET_{}_RUNNER",
@@ -154,9 +168,9 @@ fn rmain(config: &mut Config) -> Result<()> {
         .unwrap_or_else(|_| ("wasmer".to_string(), true));
 
     let mut check_deps = false;
-    match subcommand {
+    match &subcommand {
         Subcommand::DownloadToolchain => {
-            let version = args
+            let version = cargo_args
                 .first()
                 .cloned()
                 .map(|v| v.into_string().unwrap().into())
@@ -266,13 +280,8 @@ fn rmain(config: &mut Config) -> Result<()> {
         config.status("Running", &format!("`{}`", run.join(" ")));
         let mut cmd = Command::new(&wasix_runner);
 
-        if wasix_runner == "wasmer" {
-            cmd.arg("--enable-threads");
-        }
-
-        cmd.arg("--")
-            .args(run.iter())
-            .run()
+        runtime::configure_runtime_command(&mut cmd, &wasix_runner, &runtime_args, run);
+        cmd.run()
             .map_err(|e| utils::hide_normal_process_exit(e, config))?;
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -50,7 +50,8 @@ pub fn configure_runtime_command(
 
 /// Whether automatic runtime defaults are disabled via environment variable.
 pub fn run_defaults_disabled() -> bool {
-    env::var("CARGO_WASIX_NO_RUN_DEFAULTS").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    env::var("CARGO_WASIX_NO_RUN_DEFAULTS")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 /// Build default wasmer/runtime flags for `test` and `bench`.
@@ -141,11 +142,7 @@ pub fn resolve_manifest_dir(cargo_args: &[OsString]) -> Result<PathBuf> {
 }
 
 fn volume_arg(host_dir: &Path, guest_dir: &str) -> String {
-    format!(
-        "--volume={}:{}",
-        host_dir.display(),
-        guest_dir
-    )
+    format!("--volume={}:{}", host_dir.display(), guest_dir)
 }
 
 fn forward_env(args: &mut Vec<String>, key: &str) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,265 @@
+use anyhow::{Context, Result, bail};
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::utils::CommandExt;
+
+const GUEST_PROJECT_DIR: &str = "/project";
+const GUEST_TMP_DIR: &str = "/tmp";
+
+/// Returns true when the configured runner is wasmer.
+pub fn is_wasmer_runner(runner: &str) -> bool {
+    if runner == "wasmer" {
+        return true;
+    }
+    Path::new(runner)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "wasmer")
+}
+
+/// Configure a runtime invocation for the given runner.
+///
+/// Wasmer 7+ expects `wasmer run [OPTIONS] <INPUT> [-- ARGS...]`. Other runners
+/// keep the legacy `runner [OPTIONS] -- <INPUT> [ARGS...]` shape.
+pub fn configure_runtime_command(
+    cmd: &mut Command,
+    runner: &str,
+    runtime_args: &[String],
+    run: &[String],
+) {
+    if is_wasmer_runner(runner) {
+        cmd.arg("run");
+        cmd.args(runtime_args);
+        if let Some((wasm, guest)) = run.split_first() {
+            cmd.arg(wasm);
+            if !guest.is_empty() {
+                cmd.arg("--");
+                cmd.args(guest);
+            }
+        }
+    } else {
+        cmd.args(runtime_args);
+        cmd.arg("--");
+        cmd.args(run);
+    }
+}
+
+/// Whether automatic runtime defaults are disabled via environment variable.
+pub fn run_defaults_disabled() -> bool {
+    env::var("CARGO_WASIX_NO_RUN_DEFAULTS").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+/// Build default wasmer/runtime flags for `test` and `bench`.
+pub fn default_runtime_args(manifest_dir: &Path) -> Result<Vec<String>> {
+    if run_defaults_disabled() {
+        return Ok(Vec::new());
+    }
+
+    let manifest_dir = absolute_host_path(manifest_dir)?;
+    let temp_dir = absolute_host_path(&env::temp_dir())?;
+
+    let mut args = vec![
+        volume_arg(&manifest_dir, GUEST_PROJECT_DIR),
+        volume_arg(&temp_dir, GUEST_TMP_DIR),
+        "--cwd".to_string(),
+        GUEST_PROJECT_DIR.to_string(),
+    ];
+
+    forward_env(&mut args, "RUST_BACKTRACE");
+    forward_env(&mut args, "RUST_TEST_THREADS");
+
+    Ok(args)
+}
+
+/// Resolve the active package manifest directory from cargo metadata.
+pub fn resolve_manifest_dir(cargo_args: &[OsString]) -> Result<PathBuf> {
+    let package_name = package_name_from_args(cargo_args)?;
+
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--no-deps")
+        .arg("--format-version=1")
+        .capture_stdout()?;
+    let metadata = serde_json::from_str::<cargo_metadata::Metadata>(&output)
+        .context("failed to deserialize `cargo metadata`")?;
+
+    let package = if let Some(name) = package_name {
+        metadata
+            .packages
+            .iter()
+            .find(|pkg| pkg.name == name)
+            .with_context(|| format!("package `{name}` not found in workspace"))?
+    } else if let Some(root_id) = metadata
+        .resolve
+        .as_ref()
+        .and_then(|resolve| resolve.root.as_ref())
+    {
+        metadata
+            .packages
+            .iter()
+            .find(|pkg| pkg.id == *root_id)
+            .context("root package not found in `cargo metadata`")?
+    } else if metadata.packages.len() == 1 {
+        &metadata.packages[0]
+    } else {
+        let cwd = absolute_host_path(Path::new("."))?;
+        metadata
+            .packages
+            .iter()
+            .find(|pkg| {
+                pkg.manifest_path
+                    .parent()
+                    .map(|manifest_dir| absolute_host_path(Path::new(manifest_dir.as_str())))
+                    .transpose()
+                    .ok()
+                    .flatten()
+                    .is_some_and(|manifest_dir| manifest_dir == cwd)
+            })
+            .with_context(|| {
+                format!(
+                    "failed to determine active package from `cargo metadata`; \
+                     use `-p` to select one of: {}",
+                    metadata
+                        .packages
+                        .iter()
+                        .map(|pkg| pkg.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?
+    };
+
+    package
+        .manifest_path
+        .parent()
+        .context("package manifest path has no parent directory")
+        .map(|path| PathBuf::from(path.as_str()))
+}
+
+fn volume_arg(host_dir: &Path, guest_dir: &str) -> String {
+    format!(
+        "--volume={}:{}",
+        host_dir.display(),
+        guest_dir
+    )
+}
+
+fn forward_env(args: &mut Vec<String>, key: &str) {
+    if let Ok(value) = env::var(key) {
+        args.push("--env".to_string());
+        args.push(format!("{key}={value}"));
+    }
+}
+
+fn absolute_host_path(path: &Path) -> Result<PathBuf> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()?.join(path)
+    };
+    Ok(fs::canonicalize(&abs).unwrap_or(abs))
+}
+
+fn package_name_from_args(cargo_args: &[OsString]) -> Result<Option<String>> {
+    let mut iter = cargo_args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        let Some(text) = arg.to_str() else {
+            continue;
+        };
+
+        if text == "--" {
+            break;
+        }
+
+        if text == "-p" || text == "--package" {
+            let Some(value) = iter.next() else {
+                bail!("`{text}` requires a package name");
+            };
+            return value
+                .clone()
+                .into_string()
+                .map(Some)
+                .map_err(|_| anyhow::anyhow!("package name must be valid UTF-8"));
+        }
+
+        if let Some(value) = text.strip_prefix("--package=") {
+            if value.is_empty() {
+                bail!("`--package=` requires a package name");
+            }
+            return Ok(Some(value.to_string()));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_package_flag() {
+        let args = [
+            OsString::from("--release"),
+            OsString::from("-p"),
+            OsString::from("member"),
+        ];
+        assert_eq!(
+            package_name_from_args(&args).unwrap(),
+            Some("member".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_long_package_flag() {
+        let args = [OsString::from("--package=member")];
+        assert_eq!(
+            package_name_from_args(&args).unwrap(),
+            Some("member".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_package_after_double_dash() {
+        let args = [
+            OsString::from("--"),
+            OsString::from("-p"),
+            OsString::from("member"),
+        ];
+        assert_eq!(package_name_from_args(&args).unwrap(), None);
+    }
+
+    #[test]
+    fn recognizes_wasmer_runner() {
+        assert!(is_wasmer_runner("wasmer"));
+        assert!(is_wasmer_runner("/usr/bin/wasmer"));
+        assert!(!is_wasmer_runner("echo"));
+    }
+
+    #[test]
+    fn default_runtime_args_include_mounts_and_cwd() {
+        let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-test");
+        fs::create_dir_all(&dir).unwrap();
+        let args = default_runtime_args(&dir).unwrap();
+        let joined = args.join(" ");
+        assert!(joined.contains("--volume="));
+        assert!(joined.contains("/project"));
+        assert!(joined.contains("/tmp"));
+        assert!(joined.contains("--cwd /project"));
+    }
+
+    #[test]
+    fn default_runtime_args_respect_disable_env_var() {
+        let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-disabled");
+        fs::create_dir_all(&dir).unwrap();
+        // SAFETY: test-only single-threaded env mutation.
+        unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", "1") };
+        let args = default_runtime_args(&dir).unwrap();
+        unsafe { env::remove_var("CARGO_WASIX_NO_RUN_DEFAULTS") };
+        assert!(args.is_empty());
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -28,7 +28,7 @@ pub fn is_wasmer_runner(runner: &str) -> bool {
 pub fn configure_runtime_command(
     cmd: &mut Command,
     runner: &str,
-    runtime_args: &[String],
+    runtime_args: &[OsString],
     run: &[String],
 ) {
     cmd.args(runtime_invocation_args(runner, runtime_args, run));
@@ -37,24 +37,24 @@ pub fn configure_runtime_command(
 /// Build the argument list passed to a runtime executable (excluding argv[0]).
 pub(crate) fn runtime_invocation_args(
     runner: &str,
-    runtime_args: &[String],
+    runtime_args: &[OsString],
     run: &[String],
-) -> Vec<String> {
+) -> Vec<OsString> {
     if is_wasmer_runner(runner) {
-        let mut args = vec!["run".to_string()];
+        let mut args = vec![OsString::from("run")];
         args.extend(runtime_args.iter().cloned());
         if let Some((wasm, guest)) = run.split_first() {
-            args.push(wasm.clone());
+            args.push(OsString::from(wasm));
             if !guest.is_empty() {
-                args.push("--".to_string());
-                args.extend(guest.iter().cloned());
+                args.push(OsString::from("--"));
+                args.extend(guest.iter().map(|arg| OsString::from(arg)));
             }
         }
         args
     } else {
         let mut args = runtime_args.to_vec();
-        args.push("--".to_string());
-        args.extend(run.iter().cloned());
+        args.push(OsString::from("--"));
+        args.extend(run.iter().map(|arg| OsString::from(arg)));
         args
     }
 }
@@ -66,7 +66,7 @@ pub fn run_defaults_disabled() -> bool {
 }
 
 /// Build default wasmer/runtime flags for `test` and `bench`.
-pub fn default_runtime_args(manifest_dir: &Path) -> Result<Vec<String>> {
+pub fn default_runtime_args(manifest_dir: &Path) -> Result<Vec<OsString>> {
     if run_defaults_disabled() {
         return Ok(Vec::new());
     }
@@ -77,8 +77,8 @@ pub fn default_runtime_args(manifest_dir: &Path) -> Result<Vec<String>> {
     let mut args = vec![
         volume_arg(&manifest_dir, GUEST_PROJECT_DIR),
         volume_arg(&temp_dir, GUEST_TMP_DIR),
-        "--cwd".to_string(),
-        GUEST_PROJECT_DIR.to_string(),
+        OsString::from("--cwd"),
+        OsString::from(GUEST_PROJECT_DIR),
     ];
 
     forward_env(&mut args, "RUST_BACKTRACE");
@@ -163,14 +163,14 @@ pub fn resolve_manifest_dir(cargo_args: &[OsString]) -> Result<PathBuf> {
         .map(|path| PathBuf::from(path.as_str()))
 }
 
-fn volume_arg(host_dir: &Path, guest_dir: &str) -> String {
-    format!("--volume={}:{}", host_dir.display(), guest_dir)
+fn volume_arg(host_dir: &Path, guest_dir: &str) -> OsString {
+    OsString::from(format!("--volume={}:{}", host_dir.display(), guest_dir))
 }
 
-fn forward_env(args: &mut Vec<String>, key: &str) {
+fn forward_env(args: &mut Vec<OsString>, key: &str) {
     if let Ok(value) = env::var(key) {
-        args.push("--env".to_string());
-        args.push(format!("{key}={value}"));
+        args.push(OsString::from("--env"));
+        args.push(OsString::from(format!("{key}={value}")));
     }
 }
 
@@ -186,9 +186,7 @@ fn absolute_host_path(path: &Path) -> Result<PathBuf> {
 fn package_name_from_args(cargo_args: &[OsString]) -> Result<Option<String>> {
     let mut iter = cargo_args.iter().peekable();
     while let Some(arg) = iter.next() {
-        let Some(text) = arg.to_str() else {
-            continue;
-        };
+        let text = arg.to_str().context("argument must be valid UTF-8")?;
 
         if text == "--" {
             break;
@@ -219,9 +217,7 @@ fn package_name_from_args(cargo_args: &[OsString]) -> Result<Option<String>> {
 fn manifest_path_from_args(cargo_args: &[OsString]) -> Result<Option<OsString>> {
     let mut iter = cargo_args.iter().peekable();
     while let Some(arg) = iter.next() {
-        let Some(text) = arg.to_str() else {
-            continue;
-        };
+        let text = arg.to_str().context("argument must be valid UTF-8")?;
 
         if text == "--" {
             break;
@@ -339,7 +335,7 @@ mod tests {
     fn wasmer_runtime_invocation_uses_run_subcommand() {
         let args = runtime_invocation_args(
             "wasmer",
-            &["--quiet".to_string()],
+            &[OsString::from("--quiet")],
             &[
                 "foo.wasm".to_string(),
                 "guest-arg".to_string(),
@@ -349,12 +345,12 @@ mod tests {
         assert_eq!(
             args,
             vec![
-                "run".to_string(),
-                "--quiet".to_string(),
-                "foo.wasm".to_string(),
-                "--".to_string(),
-                "guest-arg".to_string(),
-                "--color=never".to_string(),
+                OsString::from("run"),
+                OsString::from("--quiet"),
+                OsString::from("foo.wasm"),
+                OsString::from("--"),
+                OsString::from("guest-arg"),
+                OsString::from("--color=never"),
             ]
         );
     }
@@ -362,24 +358,27 @@ mod tests {
     #[test]
     fn wasmer_runtime_invocation_omits_guest_separator_without_guest_args() {
         let args = runtime_invocation_args("wasmer", &[], &["foo.wasm".to_string()]);
-        assert_eq!(args, vec!["run".to_string(), "foo.wasm".to_string()]);
+        assert_eq!(
+            args,
+            vec![OsString::from("run"), OsString::from("foo.wasm")]
+        );
     }
 
     #[test]
     fn non_wasmer_runtime_invocation_uses_legacy_shape() {
         let args = runtime_invocation_args(
             "echo",
-            &["--volume".to_string(), ".:/app".to_string()],
+            &[OsString::from("--volume"), OsString::from(".:/app")],
             &["foo.wasm".to_string(), "guest".to_string()],
         );
         assert_eq!(
             args,
             vec![
-                "--volume".to_string(),
-                ".:/app".to_string(),
-                "--".to_string(),
-                "foo.wasm".to_string(),
-                "guest".to_string(),
+                OsString::from("--volume"),
+                OsString::from(".:/app"),
+                OsString::from("--"),
+                OsString::from("foo.wasm"),
+                OsString::from("guest"),
             ]
         );
     }
@@ -429,7 +428,11 @@ mod tests {
         let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-test");
         fs::create_dir_all(&dir).unwrap();
         let args = default_runtime_args(&dir).unwrap();
-        let joined = args.join(" ");
+        let joined = args
+            .iter()
+            .map(|arg| arg.to_str().unwrap())
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(joined.contains("--volume="));
         assert!(joined.contains("/project"));
         assert!(joined.contains("/tmp"));
@@ -487,7 +490,7 @@ mod tests {
             Some(value) => unsafe { env::set_var("RUST_TEST_THREADS", value) },
             None => unsafe { env::remove_var("RUST_TEST_THREADS") },
         }
-        assert!(args.contains(&"--env".to_string()));
+        assert!(args.contains(&OsString::from("--env")));
         assert!(args.iter().any(|arg| arg == "RUST_BACKTRACE=1"));
         assert!(args.iter().any(|arg| arg == "RUST_TEST_THREADS=4"));
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -61,9 +61,8 @@ pub(crate) fn runtime_invocation_args(
 
 /// Whether automatic runtime defaults are disabled via environment variable.
 pub fn run_defaults_disabled() -> bool {
-    env::var("CARGO_WASIX_NO_RUN_DEFAULTS").is_ok_and(|v| {
-        v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes")
-    })
+    env::var("CARGO_WASIX_NO_RUN_DEFAULTS")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes"))
 }
 
 /// Build default wasmer/runtime flags for `test` and `bench`.
@@ -93,8 +92,7 @@ pub fn resolve_manifest_dir(cargo_args: &[OsString]) -> Result<PathBuf> {
     let manifest_path = manifest_path_from_args(cargo_args)?;
     if let Some(path) = manifest_path {
         let manifest_path = absolute_host_path(Path::new(
-            path.to_str()
-                .context("manifest path must be valid UTF-8")?,
+            path.to_str().context("manifest path must be valid UTF-8")?,
         ))?;
         return manifest_path
             .parent()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,13 +12,13 @@ const GUEST_TMP_DIR: &str = "/tmp";
 
 /// Returns true when the configured runner is wasmer.
 pub fn is_wasmer_runner(runner: &str) -> bool {
-    if runner == "wasmer" {
+    if runner.eq_ignore_ascii_case("wasmer") {
         return true;
     }
     Path::new(runner)
-        .file_name()
+        .file_stem()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "wasmer")
+        .is_some_and(|name| name.eq_ignore_ascii_case("wasmer"))
 }
 
 /// Configure a runtime invocation for the given runner.
@@ -31,27 +31,39 @@ pub fn configure_runtime_command(
     runtime_args: &[String],
     run: &[String],
 ) {
+    cmd.args(runtime_invocation_args(runner, runtime_args, run));
+}
+
+/// Build the argument list passed to a runtime executable (excluding argv[0]).
+pub(crate) fn runtime_invocation_args(
+    runner: &str,
+    runtime_args: &[String],
+    run: &[String],
+) -> Vec<String> {
     if is_wasmer_runner(runner) {
-        cmd.arg("run");
-        cmd.args(runtime_args);
+        let mut args = vec!["run".to_string()];
+        args.extend(runtime_args.iter().cloned());
         if let Some((wasm, guest)) = run.split_first() {
-            cmd.arg(wasm);
+            args.push(wasm.clone());
             if !guest.is_empty() {
-                cmd.arg("--");
-                cmd.args(guest);
+                args.push("--".to_string());
+                args.extend(guest.iter().cloned());
             }
         }
+        args
     } else {
-        cmd.args(runtime_args);
-        cmd.arg("--");
-        cmd.args(run);
+        let mut args = runtime_args.to_vec();
+        args.push("--".to_string());
+        args.extend(run.iter().cloned());
+        args
     }
 }
 
 /// Whether automatic runtime defaults are disabled via environment variable.
 pub fn run_defaults_disabled() -> bool {
-    env::var("CARGO_WASIX_NO_RUN_DEFAULTS")
-        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    env::var("CARGO_WASIX_NO_RUN_DEFAULTS").is_ok_and(|v| {
+        v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes")
+    })
 }
 
 /// Build default wasmer/runtime flags for `test` and `bench`.
@@ -78,6 +90,18 @@ pub fn default_runtime_args(manifest_dir: &Path) -> Result<Vec<String>> {
 
 /// Resolve the active package manifest directory from cargo metadata.
 pub fn resolve_manifest_dir(cargo_args: &[OsString]) -> Result<PathBuf> {
+    let manifest_path = manifest_path_from_args(cargo_args)?;
+    if let Some(path) = manifest_path {
+        let manifest_path = absolute_host_path(Path::new(
+            path.to_str()
+                .context("manifest path must be valid UTF-8")?,
+        ))?;
+        return manifest_path
+            .parent()
+            .context("package manifest path has no parent directory")
+            .map(|path| path.to_path_buf());
+    }
+
     let package_name = package_name_from_args(cargo_args)?;
 
     let output = Command::new("cargo")
@@ -194,9 +218,173 @@ fn package_name_from_args(cargo_args: &[OsString]) -> Result<Option<String>> {
     Ok(None)
 }
 
+fn manifest_path_from_args(cargo_args: &[OsString]) -> Result<Option<OsString>> {
+    let mut iter = cargo_args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        let Some(text) = arg.to_str() else {
+            continue;
+        };
+
+        if text == "--" {
+            break;
+        }
+
+        if text == "--manifest-path" {
+            let Some(value) = iter.next() else {
+                bail!("`--manifest-path` requires a path");
+            };
+            return Ok(Some(value.clone()));
+        }
+
+        if let Some(value) = text.strip_prefix("--manifest-path=") {
+            if value.is_empty() {
+                bail!("`--manifest-path=` requires a path");
+            }
+            return Ok(Some(OsString::from(value)));
+        }
+    }
+
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn workspace_with_members(root: &Path) {
+        let _ = fs::remove_dir_all(root);
+        fs::create_dir_all(root.join("a/src")).unwrap();
+        fs::create_dir_all(root.join("b/src")).unwrap();
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+                [workspace]
+                members = ["a", "b"]
+                resolver = "2"
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("a/Cargo.toml"),
+            r#"
+                [package]
+                name = "a"
+                version = "1.0.0"
+            "#,
+        )
+        .unwrap();
+        fs::write(root.join("a/src/lib.rs"), "").unwrap();
+        fs::write(
+            root.join("b/Cargo.toml"),
+            r#"
+                [package]
+                name = "b"
+                version = "1.0.0"
+            "#,
+        )
+        .unwrap();
+        fs::write(root.join("b/src/lib.rs"), "").unwrap();
+    }
+
+    #[test]
+    fn resolve_manifest_dir_honors_manifest_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = env::temp_dir().join(format!(
+            "cargo-wasix-resolve-manifest-path-{}",
+            std::process::id()
+        ));
+        workspace_with_members(&root);
+
+        let previous_cwd = env::current_dir().unwrap();
+        env::set_current_dir(root.join("b")).unwrap();
+
+        let manifest_path = root.join("a/Cargo.toml");
+        let cargo_args = [
+            OsString::from("--manifest-path"),
+            manifest_path.into_os_string(),
+        ];
+        let resolved = resolve_manifest_dir(&cargo_args).unwrap();
+        let expected = fs::canonicalize(root.join("a")).unwrap();
+
+        env::set_current_dir(previous_cwd).unwrap();
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_manifest_dir_honors_package_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = env::temp_dir().join(format!(
+            "cargo-wasix-resolve-package-flag-{}",
+            std::process::id()
+        ));
+        workspace_with_members(&root);
+
+        let previous_cwd = env::current_dir().unwrap();
+        env::set_current_dir(&root).unwrap();
+
+        let cargo_args = [OsString::from("-p"), OsString::from("a")];
+        let resolved = resolve_manifest_dir(&cargo_args).unwrap();
+        let expected = fs::canonicalize(root.join("a")).unwrap();
+
+        env::set_current_dir(previous_cwd).unwrap();
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn wasmer_runtime_invocation_uses_run_subcommand() {
+        let args = runtime_invocation_args(
+            "wasmer",
+            &["--quiet".to_string()],
+            &[
+                "foo.wasm".to_string(),
+                "guest-arg".to_string(),
+                "--color=never".to_string(),
+            ],
+        );
+        assert_eq!(
+            args,
+            vec![
+                "run".to_string(),
+                "--quiet".to_string(),
+                "foo.wasm".to_string(),
+                "--".to_string(),
+                "guest-arg".to_string(),
+                "--color=never".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn wasmer_runtime_invocation_omits_guest_separator_without_guest_args() {
+        let args = runtime_invocation_args("wasmer", &[], &["foo.wasm".to_string()]);
+        assert_eq!(args, vec!["run".to_string(), "foo.wasm".to_string()]);
+    }
+
+    #[test]
+    fn non_wasmer_runtime_invocation_uses_legacy_shape() {
+        let args = runtime_invocation_args(
+            "echo",
+            &["--volume".to_string(), ".:/app".to_string()],
+            &["foo.wasm".to_string(), "guest".to_string()],
+        );
+        assert_eq!(
+            args,
+            vec![
+                "--volume".to_string(),
+                ".:/app".to_string(),
+                "--".to_string(),
+                "foo.wasm".to_string(),
+                "guest".to_string(),
+            ]
+        );
+    }
 
     #[test]
     fn parses_package_flag() {
@@ -234,6 +422,7 @@ mod tests {
     fn recognizes_wasmer_runner() {
         assert!(is_wasmer_runner("wasmer"));
         assert!(is_wasmer_runner("/usr/bin/wasmer"));
+        assert!(is_wasmer_runner("/usr/bin/wasmer.exe"));
         assert!(!is_wasmer_runner("echo"));
     }
 
@@ -250,13 +439,106 @@ mod tests {
     }
 
     #[test]
+    fn parses_manifest_path_flag() {
+        let args = [
+            OsString::from("--release"),
+            OsString::from("--manifest-path"),
+            OsString::from("other/Cargo.toml"),
+        ];
+        assert_eq!(
+            manifest_path_from_args(&args).unwrap(),
+            Some(OsString::from("other/Cargo.toml"))
+        );
+    }
+
+    #[test]
+    fn parses_long_manifest_path_flag() {
+        let args = [OsString::from("--manifest-path=other/Cargo.toml")];
+        assert_eq!(
+            manifest_path_from_args(&args).unwrap(),
+            Some(OsString::from("other/Cargo.toml"))
+        );
+    }
+
+    #[test]
+    fn ignores_manifest_path_after_double_dash() {
+        let args = [
+            OsString::from("--"),
+            OsString::from("--manifest-path"),
+            OsString::from("other/Cargo.toml"),
+        ];
+        assert_eq!(manifest_path_from_args(&args).unwrap(), None);
+    }
+
+    #[test]
+    fn default_runtime_args_forward_env_vars() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-env");
+        fs::create_dir_all(&dir).unwrap();
+        let previous_backtrace = env::var("RUST_BACKTRACE").ok();
+        let previous_threads = env::var("RUST_TEST_THREADS").ok();
+        // SAFETY: guarded by ENV_LOCK and previous values are restored below.
+        unsafe { env::set_var("RUST_BACKTRACE", "1") };
+        unsafe { env::set_var("RUST_TEST_THREADS", "4") };
+        let args = default_runtime_args(&dir).unwrap();
+        match previous_backtrace {
+            Some(value) => unsafe { env::set_var("RUST_BACKTRACE", value) },
+            None => unsafe { env::remove_var("RUST_BACKTRACE") },
+        }
+        match previous_threads {
+            Some(value) => unsafe { env::set_var("RUST_TEST_THREADS", value) },
+            None => unsafe { env::remove_var("RUST_TEST_THREADS") },
+        }
+        assert!(args.contains(&"--env".to_string()));
+        assert!(args.iter().any(|arg| arg == "RUST_BACKTRACE=1"));
+        assert!(args.iter().any(|arg| arg == "RUST_TEST_THREADS=4"));
+    }
+
+    #[test]
+    fn default_runtime_args_respect_disable_env_var_yes() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-disabled-yes");
+        fs::create_dir_all(&dir).unwrap();
+        let previous = env::var("CARGO_WASIX_NO_RUN_DEFAULTS").ok();
+        // SAFETY: guarded by ENV_LOCK and previous value is restored below.
+        unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", "Yes") };
+        let args = default_runtime_args(&dir).unwrap();
+        match previous {
+            Some(value) => unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", value) },
+            None => unsafe { env::remove_var("CARGO_WASIX_NO_RUN_DEFAULTS") },
+        }
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn default_runtime_args_respect_disable_env_var_true() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-disabled-true");
+        fs::create_dir_all(&dir).unwrap();
+        let previous = env::var("CARGO_WASIX_NO_RUN_DEFAULTS").ok();
+        // SAFETY: guarded by ENV_LOCK and previous value is restored below.
+        unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", "TRUE") };
+        let args = default_runtime_args(&dir).unwrap();
+        match previous {
+            Some(value) => unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", value) },
+            None => unsafe { env::remove_var("CARGO_WASIX_NO_RUN_DEFAULTS") },
+        }
+        assert!(args.is_empty());
+    }
+
+    #[test]
     fn default_runtime_args_respect_disable_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let dir = env::temp_dir().join("cargo-wasix-runtime-defaults-disabled");
         fs::create_dir_all(&dir).unwrap();
-        // SAFETY: test-only single-threaded env mutation.
+        let previous = env::var("CARGO_WASIX_NO_RUN_DEFAULTS").ok();
+        // SAFETY: guarded by ENV_LOCK and previous value is restored below.
         unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", "1") };
         let args = default_runtime_args(&dir).unwrap();
-        unsafe { env::remove_var("CARGO_WASIX_NO_RUN_DEFAULTS") };
+        match previous {
+            Some(value) => unsafe { env::set_var("CARGO_WASIX_NO_RUN_DEFAULTS", value) },
+            None => unsafe { env::remove_var("CARGO_WASIX_NO_RUN_DEFAULTS") },
+        }
         assert!(args.is_empty());
     }
 }

--- a/src/txt/help.txt
+++ b/src/txt/help.txt
@@ -20,3 +20,18 @@ All options accepted are the same as that of the corresponding `cargo`
 subcommands. You can run `cargo wasix build -h` for more information to learn
 about flags that can be passed to `cargo wasix build`, which mirrors the
 `cargo build` command.
+
+RUNTIME OPTIONS:
+    -W,<ARGS>    Pass comma-separated arguments through to the WASIX runtime
+                 (e.g. wasmer). Same idea as clang's -Wl,. Applies to run,
+                 test, and bench. Arguments after `--` are forwarded to the
+                 WASM guest or test harness instead.
+
+                 Example: cargo wasix run -W,--volume,./src:/app
+
+TEST/BENCH DEFAULTS:
+    test and bench automatically mount the package directory at /project
+    (with CWD /project) and map the host temp directory to /tmp. Selected
+    environment variables (RUST_BACKTRACE, RUST_TEST_THREADS) are forwarded
+    when set on the host. Set CARGO_WASIX_NO_RUN_DEFAULTS=1 to disable.
+    run has no filesystem defaults; use -W,... when needed.

--- a/src/txt/help.txt
+++ b/src/txt/help.txt
@@ -33,5 +33,5 @@ TEST/BENCH DEFAULTS:
     test and bench automatically mount the package directory at /project
     (with CWD /project) and map the host temp directory to /tmp. Selected
     environment variables (RUST_BACKTRACE, RUST_TEST_THREADS) are forwarded
-    when set on the host. Set CARGO_WASIX_NO_RUN_DEFAULTS=1 to disable.
+    when set on the host. Set CARGO_WASIX_NO_RUN_DEFAULTS=1 (or true/yes) to disable.
     run has no filesystem defaults; use -W,... when needed.

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -599,6 +599,94 @@ fn run_forward_args() -> Result<()> {
 }
 
 #[test]
+fn wasmer_arg_stripped_on_build() -> Result<()> {
+    support::project()
+        .file("src/main.rs", "fn main() {}")
+        .build()
+        .cargo_wasix("build -W,--not-a-cargo-flag")
+        .assert()
+        .success();
+    Ok(())
+}
+
+#[test]
+fn run_forward_args_with_wasmer_arg() -> Result<()> {
+    support::project()
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    println!("{:?}", std::env::args().skip(1).collect::<Vec<_>>());
+                }
+            "#,
+        )
+        .build()
+        .cargo_wasix("run -W,--quiet a -b c")
+        .assert()
+        .stdout("[\"a\", \"-b\", \"c\", \"--color=never\"]\n")
+        .success();
+    Ok(())
+}
+
+#[test]
+fn run_wasmer_arg_pass_through_echo() -> Result<()> {
+    support::project()
+        .file("src/main.rs", "fn main() {}")
+        .override_runtime("echo")
+        .build()
+        .cargo_wasix("run -W,--volume,./src:/app,--cwd,/app")
+        .assert()
+        .stdout(is_match("--volume")?)
+        .stdout(is_match("/app")?)
+        .success();
+    Ok(())
+}
+
+#[test]
+fn test_reads_fixture_with_defaults() -> Result<()> {
+    support::project()
+        .file("tests/data.txt", "fixture-data\n")
+        .file(
+            "src/lib.rs",
+            r#"
+                #[test]
+                fn reads_fixture() {
+                    let content = std::fs::read_to_string("tests/data.txt").unwrap();
+                    assert_eq!(content, "fixture-data\n");
+                }
+            "#,
+        )
+        .build()
+        .cargo_wasix("test reads_fixture")
+        .assert()
+        .stdout(contains("test result: ok. 1 passed; 0 failed"))
+        .success();
+    Ok(())
+}
+
+#[test]
+fn test_reads_fixture_without_defaults_fails() -> Result<()> {
+    support::project()
+        .file("tests/data.txt", "fixture-data\n")
+        .file(
+            "src/lib.rs",
+            r#"
+                #[test]
+                fn reads_fixture() {
+                    let content = std::fs::read_to_string("tests/data.txt").unwrap();
+                    assert_eq!(content, "fixture-data\n");
+                }
+            "#,
+        )
+        .build()
+        .cargo_wasix("test reads_fixture")
+        .env("CARGO_WASIX_NO_RUN_DEFAULTS", "1")
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[test]
 fn test() -> Result<()> {
     support::project()
         .file(

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -665,6 +665,39 @@ fn test_reads_fixture_with_defaults() -> Result<()> {
 }
 
 #[test]
+fn bench_reads_fixture_with_defaults() -> Result<()> {
+    support::project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "1.0.0"
+
+                [[bench]]
+                name = "fixture"
+                harness = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("benches/data.txt", "fixture-data\n")
+        .file(
+            "benches/fixture.rs",
+            r#"
+                fn main() {
+                    let content = std::fs::read_to_string("benches/data.txt").unwrap();
+                    assert_eq!(content, "fixture-data\n");
+                }
+            "#,
+        )
+        .build()
+        .cargo_wasix("bench --bench fixture")
+        .assert()
+        .success();
+    Ok(())
+}
+
+#[test]
 fn test_reads_fixture_without_defaults_fails() -> Result<()> {
     support::project()
         .file("tests/data.txt", "fixture-data\n")


### PR DESCRIPTION
## Summary
- Add clang-style `-W,<args>` pass-through for wasmer/runtime flags on `run`, `test`, and `bench`
- Add automatic test/bench runtime defaults (project mount at `/project`, temp at `/tmp`, selective env forwarding)
- Invoke wasmer via `wasmer run` on Wasmer 7+ and remove the obsolete hardcoded `--enable-threads` flag

## Test plan
- [x] `cargo test -p cargo-wasix --lib args:: runtime::`
- [x] `cargo test -p cargo-wasix --test tests wasmer_arg`
- [x] `cargo test -p cargo-wasix --test tests test_reads_fixture`
- [x] `cargo test -p cargo-wasix --test tests run_forward_args`


Made with [Cursor](https://cursor.com)