### PR TITLE
Add CARGO_WASIX_NO_REGISTRY_CONFIG to skip the automatic config write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,8 @@ fn rmain(config: &mut Config) -> Result<()> {
     // the dependency graph (`download-toolchain` returned above), including
     // `tree` (which should show the fork versions a build would use) and
     // `fix` (which compiles just like `check`).
-    if let Some(workspace_root) = &workspace_root
+    if !registry::config_write_disabled()
+        && let Some(workspace_root) = &workspace_root
         && let Err(err) = registry::ensure_config(config, workspace_root)
     {
         config.warn(&format!("failed to configure the WASIX registry: {err:#}"));

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -42,6 +42,15 @@ pub enum Outcome {
     KeptForeignReplacement,
 }
 
+/// Whether the automatic registry-config write is disabled via environment
+/// variable. Escape hatch for building without the overlay registry (e.g.
+/// bootstrapping the registry itself while it's down); an explicit
+/// `cargo wasix init` still works.
+pub fn config_write_disabled() -> bool {
+    std::env::var("CARGO_WASIX_NO_REGISTRY_CONFIG")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes"))
+}
+
 /// `cargo wasix init`: applies the registry config and nothing else.
 pub fn init(config: &Config, workspace_root: &Path) -> Result<()> {
     if ensure_config(config, workspace_root)? == Outcome::AlreadyConfigured {

--- a/src/txt/help.txt
+++ b/src/txt/help.txt
@@ -27,7 +27,10 @@ INIT:
     .cargo/config.toml and does nothing else — no toolchain install, no
     build. The same config is applied automatically by all other
     subcommands; init exists to set up (or verify) a project explicitly,
-    e.g. before committing the config or in CI.
+    e.g. before committing the config or in CI. Set
+    CARGO_WASIX_NO_REGISTRY_CONFIG=1 (or true/yes) to disable the automatic
+    write, e.g. to build a project that deliberately does not resolve
+    through the WASIX registry.
 
 TOOLCHAIN OVERRIDE:
     +<toolchain>    Use the given rustup toolchain instead of the default

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -1054,6 +1054,25 @@ fn registry_config_written() -> Result<()> {
 }
 
 #[test]
+fn registry_config_write_can_be_disabled() -> Result<()> {
+    let p = support::project()
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cmd = p.cargo_wasix("check");
+    cmd.env("CARGO_WASIX_NO_REGISTRY_CONFIG", "1");
+    cmd.assert().success();
+    assert!(!p.root().join(".cargo").exists());
+
+    // An explicit init still works with the variable set.
+    let mut cmd = p.cargo_wasix("init");
+    cmd.env("CARGO_WASIX_NO_REGISTRY_CONFIG", "1");
+    cmd.assert().success();
+    assert!(p.root().join(".cargo").join("config.toml").exists());
+    Ok(())
+}
+
+#[test]
 fn init_writes_config_and_nothing_else() -> Result<()> {
     let p = support::project()
         .file("src/main.rs", "fn main() {}")


### PR DESCRIPTION
Escape hatch for building without the overlay registry. The immediate use case: wasix-org/cargo-registry now resolves its own dependencies through the registry it implements (dogfooding), which leaves no way to rebuild it if the deployment is down — every config-level trick to neutralize source replacement is rejected by cargo (redefining crates.io's URL, self-referential `replace-with`, and the git index URL all error). With this variable, the registry's emergency-bootstrap manifest (`Cargo.toml.old` + `Cargo.lock.old`) can build straight from the git forks:

```console
$ rm .cargo/config.toml
$ CARGO_WASIX_NO_REGISTRY_CONFIG=1 cargo wasix build --release --locked
```

- Accepts `1`/`true`/`yes`, matching `CARGO_WASIX_NO_RUN_DEFAULTS`.
- Only disables the automatic write; an explicit `cargo wasix init` still works.
- Documented in the help text; integration test covers both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)