### PR TITLE
Force wasixcc to legacy EH to match the Rust toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,20 +282,24 @@ fn rmain(config: &mut Config) -> Result<()> {
         }
     }
 
-    // For the -dl target, set wasixcc-specific environment variables
-    if target.ends_with("-dl") {
-        // Enable position-independent code for dynamic linking
-        if std::env::var("WASIXCC_PIC").is_err() {
-            // SAFETY: not safe in multi-threaded environment
-            unsafe { env::set_var("WASIXCC_PIC", "1") };
-            config.verbose(|| config.info("Set WASIXCC_PIC=1 for -dl target"));
-        }
-        // Enable WASM exceptions for better performance and C++ exception support
-        if std::env::var("WASIXCC_WASM_EXCEPTIONS").is_err() {
-            // SAFETY: not safe in multi-threaded environment
-            unsafe { env::set_var("WASIXCC_WASM_EXCEPTIONS", "1") };
-            config.verbose(|| config.info("Set WASIXCC_WASM_EXCEPTIONS=1 for -dl target"));
-        }
+    // The Rust toolchain builds in the legacy exception-handling
+    // configuration (its sysroot is the legacy-EH wasix-libc build), while
+    // wasixcc defaults to exnref. Force wasixcc to legacy — overriding any
+    // value from the environment — so C/C++ objects match the Rust side of
+    // the binary; wasm-opt translates the whole module to exnref afterwards.
+    if which::which("wasixcc").is_ok() {
+        // SAFETY: not safe in multi-threaded environment
+        unsafe { env::set_var("WASIXCC_WASM_EXCEPTIONS", "legacy") };
+        config.verbose(|| config.info("Set WASIXCC_WASM_EXCEPTIONS=legacy"));
+    }
+
+    // For the -dl target, enable position-independent code for dynamic
+    // linking (with legacy EH above, this selects wasixcc's sysroot-ehpic —
+    // the same configuration the Rust toolchain's dl sysroot uses).
+    if target.ends_with("-dl") && std::env::var("WASIXCC_PIC").is_err() {
+        // SAFETY: not safe in multi-threaded environment
+        unsafe { env::set_var("WASIXCC_PIC", "1") };
+        config.verbose(|| config.info("Set WASIXCC_PIC=1 for -dl target"));
     }
 
     // Make sure the project resolves crates through the WASIX overlay

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -1247,11 +1247,11 @@ fn wasixcc_pic_and_exceptions_for_dl_target() -> Result<()> {
             "build.rs",
             r#"
                 fn main() {
-                    if let Ok(pic) = std::env::var("WASIXCC_PIC") {
-                        println!("cargo:warning=WASIXCC_PIC is set to: {}", pic);
-                    }
-                    if let Ok(exceptions) = std::env::var("WASIXCC_WASM_EXCEPTIONS") {
-                        println!("cargo:warning=WASIXCC_WASM_EXCEPTIONS is set to: {}", exceptions);
+                    for var in ["WASIXCC_PIC", "WASIXCC_WASM_EXCEPTIONS"] {
+                        println!("cargo:rerun-if-env-changed={}", var);
+                        if let Ok(v) = std::env::var(var) {
+                            println!("cargo:warning={} is set to: {}", var, v);
+                        }
                     }
                 }
             "#,
@@ -1262,7 +1262,7 @@ fn wasixcc_pic_and_exceptions_for_dl_target() -> Result<()> {
                 [package]
                 name = "foo"
                 version = '1.0.0'
-                
+
                 [package.metadata]
                 dl = true
             "#,
@@ -1272,17 +1272,33 @@ fn wasixcc_pic_and_exceptions_for_dl_target() -> Result<()> {
     let output = p.cargo_wasix("build").assert().success();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
 
-    // For -dl target, WASIXCC_PIC and WASIXCC_WASM_EXCEPTIONS should be set
+    // For -dl target, WASIXCC_PIC should be set
     assert!(
         stderr.contains("WASIXCC_PIC is set to: 1"),
         "Expected WASIXCC_PIC=1 for -dl target, stderr:\n{}",
         stderr
     );
-    assert!(
-        stderr.contains("WASIXCC_WASM_EXCEPTIONS is set to: 1"),
-        "Expected WASIXCC_WASM_EXCEPTIONS=1 for -dl target, stderr:\n{}",
-        stderr
-    );
+    // The Rust toolchain builds in the legacy EH configuration, so wasixcc
+    // must too (its own default is exnref).
+    if which::which("wasixcc").is_ok() {
+        assert!(
+            stderr.contains("WASIXCC_WASM_EXCEPTIONS is set to: legacy"),
+            "Expected WASIXCC_WASM_EXCEPTIONS=legacy, stderr:\n{}",
+            stderr
+        );
+
+        // Even a value from the environment is overridden: mismatched EH
+        // configurations must not reach the build.
+        let mut cmd = p.cargo_wasix("build");
+        cmd.env("WASIXCC_WASM_EXCEPTIONS", "exnref");
+        let output = cmd.assert().success();
+        let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+        assert!(
+            stderr.contains("WASIXCC_WASM_EXCEPTIONS is set to: legacy"),
+            "Expected the exnref value from the environment to be overridden, stderr:\n{}",
+            stderr
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Why

The Rust toolchain builds in the **legacy** EH configuration — `build-wasix.sh` bakes wasix-libc's `sysroot32-eh`/`sysroot32-ehpic` into the toolchain, and the target spec never passes `--wasm-use-legacy-eh=false`. wasixcc, however, defaults to **exnref** (`WASM_EXCEPTIONS` unset → `sysroot-exnref-eh` + `--wasm-use-legacy-eh=false`). So with the auto-CC integration, the C/C++ objects in a build were in a different EH configuration than the Rust/libc side.

In practice this happened to work — Rust is panic=abort (no catches), `throw` is style-neutral, and wasmer supports exnref — but it's an asymmetry waiting to bite (e.g. once anything on the Rust side emits legacy catches next to exnref C catches with `wasm-opt = false` set).

## What

- When wasixcc is on PATH, set `WASIXCC_WASM_EXCEPTIONS=legacy` **unconditionally**, overriding any environment value — a mismatched EH configuration must not reach the build. Everything is still translated to exnref by the mandatory `wasm-opt --translate-to-exnref` pass.
- Drop the `-dl` target's old `WASIXCC_WASM_EXCEPTIONS=1` (exnref) default; `WASIXCC_PIC=1` remains, and with legacy EH it selects `sysroot-ehpic` — the same configuration as the Rust dl target's `sysroot32-ehpic`.

## Verified

C `setjmp`/`longjmp` compiled via the cc crate into a Rust app:
- pre-wasm-opt module: 1 legacy `try`, 0 `try_table` (wasixcc now matches the toolchain),
- post-wasm-opt: 1 `try_table`, 0 legacy (translate-to-exnref unifies),
- runs under wasmer, longjmp round-trips correctly.

Integration test updated: asserts `legacy` for the dl target and asserts that an `exnref` value in the environment is overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)