### PR TITLE
feat: support the aarch64-unknown-linux-gnu host toolchain

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -25,6 +25,9 @@ fn guess_host_target() -> Option<&'static str> {
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     return Some("x86_64-unknown-linux-gnu");
 
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    return Some("aarch64-unknown-linux-gnu");
+
     #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
     return Some("x86_64-apple-darwin");
 


### PR DESCRIPTION
## What

Add `aarch64-unknown-linux-gnu` to `guess_host_target` in `src/toolchain.rs`.

## Why

`wasix-org/rust` has shipped `rust-toolchain-aarch64-unknown-linux-gnu.tar.gz` since `v2026-08-05.1+rust-1.97`, but the host table in `guess_host_target` only ever listed four triples:

```rust
x86_64-unknown-linux-gnu, x86_64-apple-darwin,
aarch64-apple-darwin,     x86_64-pc-windows-msvc
```

On an aarch64 Linux host it therefore returns `None`, and `install_prebuilt_toolchain` fails with:

```
error: The WASIX toolchain is not available for download on this platform.
```

before it ever looks at the release assets. The asset it needs is right there in the release.

This surfaced in wasmerio/wasmer#6698, where the `linux-arm64` CI job runs the WASIX Rust test fixtures: https://github.com/wasmerio/wasmer/actions/runs/31015208374

## Notes

No other change is needed — the existing asset lookup builds the name from the triple (`rust-toolchain-{target}.tar.gz`), which already matches what the release publishes.

I did not bump the version, since that looks like a separate step in this repo. A crates.io release is required before the `wasix-org/cargo-wasix` GitHub action picks this up, as the action installs by the version in `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)