### PR TITLE
fix: download wasm-opt on aarch64 Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,6 +679,8 @@ fn install_wasm_opt(path: &ToolPath, config: &Config) -> Result<()> {
 
     let url = if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
         binaryen_url("x86_64-linux")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        binaryen_url("aarch64-linux")
     } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
         binaryen_url("x86_64-macos")
     } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {


### PR DESCRIPTION
## What

Add the `linux` + `aarch64` arm to `install_wasm_opt` in `src/lib.rs`, mapping to binaryen's `aarch64-linux` asset.

## Why

Follow-up to #85. With the host toolchain fixed, `cargo wasix build` gets all the way to post-processing on aarch64 Linux and then dies:

```
info: Post-processing WebAssembly files
  Optimizing with wasm-opt
error: failed to process wasm at `.../main.rustc.wasm`

Caused by:
    `wasm-opt` failed to execute

Caused by:
    no precompiled binaries of `wasm-opt` are available for this platform, you'll want to
    set `$WASM_OPT` to a preinstalled `wasm-opt` command or disable via `wasm-opt = false`
    in your manifest
```

`install_wasm_opt` mapped only `x86_64-linux`, `x86_64-macos`, `arm64-macos` and `x86_64-windows`, so aarch64 Linux hit the `bail!` arm. Binaryen has shipped `binaryen-version_130-aarch64-linux.tar.gz` all along — I confirmed the URL this arm constructs returns HTTP 200.

Without this, every Rust build on an aarch64 Linux host fails. It took out all 708 Rust test-fixture trials in wasmerio/wasmer#6698: https://github.com/wasmerio/wasmer/actions/runs/31015208374

## Notes

As with #85, no version bump here — a crates.io release is needed before the `wasix-org/cargo-wasix` action picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)